### PR TITLE
fix(capabilities): Remove unimplemented capabilities to prevent clien…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `mcp-server-capabilities`: the server advertised `tools.listChanged`, `resources.subscribe`, `resources.listChanged`, and `prompts.listChanged` despite never emitting any of the corresponding notifications (issue #14). Clients relying on these could wait for notifications that never arrived. Capabilities now advertise only `tools` as an empty object (`{"tools":{}}`), indicating tools exist without optional sub-capabilities. The unused `resources/list`, `resources/read`, and `prompts/list` stub handlers have been removed; requests for these methods now correctly return JSON-RPC error `-32601` (method not found)
+
 ## [0.6.0] - 2026-03-31
 
 ### Fixed

--- a/mcp-server.el
+++ b/mcp-server.el
@@ -141,10 +141,14 @@ Defaults to `user-emacs-directory'. Users can customize this with:
   :group 'mcp-server)
 
 (defvar mcp-server-capabilities
-  '((tools . ((listChanged . t)))
-    (resources . ((subscribe . t) (listChanged . t)))
-    (prompts . ((listChanged . t))))
-  "Capabilities supported by this MCP server.")
+  `((tools . ,(make-hash-table :test 'equal)))
+  "Capabilities supported by this MCP server.
+Only advertise capabilities that are actually implemented.  Empty
+hash-table for `tools' serializes to `{}', indicating tools exist
+without optional sub-capabilities.  Add `listChanged' back when a
+notification is wired up on tool register/unregister/filter changes.
+Add `resources' and `prompts' entries only when the corresponding
+handlers and notifications are implemented.")
 
 ;;; Logging
 
@@ -293,17 +297,6 @@ Uses `catch'/`throw' for early exit after successful response send."
               (mcp-server--debug "tools/call handler returned: %S" result)
               result))
 
-           ;; Resources (future implementation)
-           ((string= method "resources/list")
-            (mcp-server--handle-resources-list id params client-id))
-
-           ((string= method "resources/read")
-            (mcp-server--handle-resources-read id params client-id))
-
-           ;; Prompts (future implementation)
-           ((string= method "prompts/list")
-            (mcp-server--handle-prompts-list id params client-id))
-
            ;; Notifications
            ((string= method "notifications/initialized")
             (mcp-server--handle-initialized))
@@ -398,31 +391,6 @@ Uses `catch'/`throw' for early exit after successful response send."
       `((content . (((type . "text")
                      (text . "Tool execution failed"))))
         (isError . t))))))
-
-(defun mcp-server--handle-resources-list (id params client-id)
-  "Handle resources/list request with ID and PARAMS from CLIENT-ID.
-Returns empty list as resources feature is planned for future implementation."
-  (mcp-server--debug "Resources list request from %s: %s" client-id params)
-
-  (mcp-server--send-response
-   client-id id
-   '((resources . []))))
-
-(defun mcp-server--handle-resources-read (id params client-id)
-  "Handle resources/read request with ID and PARAMS from CLIENT-ID.
-Returns error as resources feature is planned for future implementation."
-  (mcp-server--debug "Resources read request from %s: %s" client-id params)
-
-  (mcp-server--send-error client-id id -32002 "Resource not found" params))
-
-(defun mcp-server--handle-prompts-list (id params client-id)
-  "Handle prompts/list request with ID and PARAMS from CLIENT-ID.
-Returns empty list as prompts feature is planned for future implementation."
-  (mcp-server--debug "Prompts list request from %s: %s" client-id params)
-
-  (mcp-server--send-response
-   client-id id
-   '((prompts . []))))
 
 (defun mcp-server--send-error (client-id id code message &optional data)
   "Send error response to CLIENT-ID with ID, CODE, MESSAGE and optional DATA."

--- a/test/unit/test-mcp-basic.el
+++ b/test/unit/test-mcp-basic.el
@@ -133,13 +133,11 @@
 ;;; Configuration Pattern Tests
 
 (ert-deftest mcp-test-server-capabilities-structure ()
-  "Test server capabilities structure."
-  (let ((capabilities '((tools . ((listChanged . t)))
-                        (resources . ((subscribe . t) (listChanged . t)))
-                        (prompts . ((listChanged . t))))))
-    (should (alist-get 'tools capabilities))
-    (should (alist-get 'resources capabilities))
-    (should (alist-get 'prompts capabilities))))
+  "Minimum viable capabilities advertise tools only (issue #14)."
+  (let ((capabilities `((tools . ,(make-hash-table :test 'equal)))))
+    (should (assq 'tools capabilities))
+    (should-not (assq 'resources capabilities))
+    (should-not (assq 'prompts capabilities))))
 
 (ert-deftest mcp-test-client-info-structure ()
   "Test client info structure."

--- a/test/unit/test-mcp-server-full.el
+++ b/test/unit/test-mcp-server-full.el
@@ -38,11 +38,37 @@
   (should (boundp 'mcp-server-default-transport)))
 
 (ert-deftest mcp-test-server-capabilities ()
-  "Test that server capabilities are defined."
+  "Server must only advertise capabilities it actually implements.
+Issue #14: advertising resources/prompts/listChanged we don't emit
+causes clients to wait forever or otherwise misbehave."
   (should (boundp 'mcp-server-capabilities))
-  (should (alist-get 'tools mcp-server-capabilities))
-  (should (alist-get 'resources mcp-server-capabilities))
-  (should (alist-get 'prompts mcp-server-capabilities)))
+  ;; Tools is implemented, must be advertised
+  (should (assq 'tools mcp-server-capabilities))
+  ;; Resources not implemented (tracked in #12) - must not be advertised
+  (should-not (assq 'resources mcp-server-capabilities))
+  ;; Prompts not implemented - must not be advertised
+  (should-not (assq 'prompts mcp-server-capabilities))
+  ;; tools.listChanged notification is never emitted - must not be claimed
+  (let ((tools-cap (alist-get 'tools mcp-server-capabilities)))
+    (should (or (null tools-cap)
+                (and (hash-table-p tools-cap)
+                     (zerop (hash-table-count tools-cap)))))))
+
+(ert-deftest mcp-test-server-capabilities-serialize-empty-tools-object ()
+  "Capabilities must serialize as {\"tools\":{}} for MCP spec compliance.
+Empty object indicates tools exist without optional sub-capabilities."
+  (let* ((converted (mcp-server-transport--alist-to-json mcp-server-capabilities))
+         (json-str (json-serialize converted)))
+    (should (string= json-str "{\"tools\":{}}"))))
+
+(ert-deftest mcp-test-no-unimplemented-method-handlers ()
+  "Handlers for unsupported methods must not exist.
+Issue #14: resources and prompts handlers were stubs that lied about
+support; removing them lets the method router return -32601 (method
+not found) which is the correct response."
+  (should-not (fboundp 'mcp-server--handle-resources-list))
+  (should-not (fboundp 'mcp-server--handle-resources-read))
+  (should-not (fboundp 'mcp-server--handle-prompts-list)))
 
 ;;; Server Function Tests
 


### PR DESCRIPTION
Removed advertised capabilities for tools.listChanged, resources.subscribe, resources.listChanged, and prompts.listChanged that were never actually implemented. Clients relying on these notifications could wait indefinitely.

Server now only advertises `{"tools":{}}`, indicating tools exist without optional sub-capabilities. Removed stub handlers for resources/list, resources/read, and prompts/list - requests now correctly return JSON-RPC error -32601 (method not found).

Fixes #14