### PR TITLE
fix: remove release-please marker from Version header

### DIFF
--- a/mcp-server.el
+++ b/mcp-server.el
@@ -5,7 +5,7 @@
 ;; Author: Claude Code + Rolf Håvard Blindheim<rhblind@gmail.com>
 ;; URL: https://github.com/rhblind/emacs-mcp-server
 ;; Keywords: mcp, protocol, integration, tools
-;; Version: 0.6.0 ;; x-release-please-version
+;; Version: 0.6.0
 ;; Package-Requires: ((emacs "27.1"))
 
 ;; This file is NOT part of GNU Emacs.
@@ -61,7 +61,7 @@
 
 ;;; Constants
 
-(defconst mcp-server-version "0.6.0" ; x-release-please-version
+(defconst mcp-server-version "0.6.0"
   "Version of the Emacs MCP server.")
 
 (defconst mcp-server-protocol-version "2024-11-05"


### PR DESCRIPTION
## Summary

The package header in `mcp-server.el` currently reads:

```elisp
;; Version: 0.6.0 ;; x-release-please-version
```

The trailing `;; x-release-please-version` is a release-please anchor comment, but on the `;; Version:` header line Emacs treats everything after `Version:` as the literal version value — there is no inline-comment handling for Lisp library headers.

## The bug

Emacs's `package-vc-install` (Emacs 29+) calls `package-strip-rcs-id` then `version-to-list` on whatever follows `Version:`. `version-to-list` rejects any trailing non-numeric text, so installation fails immediately:

```
Invalid version syntax: '0.6.0 ;; x-release-please-version'
```

### Affected installation methods

| Method | Affected? | Why |
| --- | --- | --- |
| `use-package :vc` (built-in `package-vc-install`) | ❌ Broken | Calls `version-to-list` on the Version header |
| `M-x package-vc-install` | ❌ Broken | Same path |
| `straight.el` | ✅ Works | Bypasses Emacs's package-header version parsing |
| Manual `load-file` / `require` | ✅ Works | Doesn't parse the Version header |

This explains why the regression went unnoticed — the marker was added two weeks ago in the release-please automation commit, and straight.el users hit no error.

## The fix

Strip the `;; x-release-please-version` / `; x-release-please-version` markers from both the package header and the runtime `defconst`, leaving a clean bare version number:

```elisp
;; Version: 0.6.0
...
(defconst mcp-server-version "0.6.0"
  "Version of the Emacs MCP server.")
```

The header line was the source of the actual bug; the `defconst` line was a valid Elisp comment but is stripped here for consistency, since the marker is no longer functional anyway (see below).

## Heads-up: release-please will need reconfiguration

The generic updater in release-please uses the inline `x-release-please-version` comment as the anchor it edits on each release. Removing the marker means the next `release-please` run will not bump the version in `mcp-server.el` automatically.

Options to consider before the next release cut:

- Move the version into a separate `VERSION` file (or a small `mcp-server-version.el`) that release-please owns, and `(require)` / read it at runtime.
- Have the release workflow run a `sed` step that rewrites the bare `;; Version:` line based on the manifest, without persisting any marker in the package header.
- Use a `release-as` block plus a non-generic updater scoped to a different file.

Happy to follow up with whichever approach you prefer — wanted to keep this PR focused on unblocking `package-vc-install` users first.

## Test plan

- [x] `grep -r x-release-please-version --include='*.el'` returns no matches
- [ ] `package-vc-install` / `use-package :vc` installs the package without the `Invalid version syntax` error
- [ ] `straight.el` installation still works (no regression expected — it never parsed the header)