### PR TITLE
fix: ownership-aware temporary org-buffer cleanup

### DIFF
--- a/mcp-server.el
+++ b/mcp-server.el
@@ -353,11 +353,12 @@ Uses `catch'/`throw' for early exit after successful response send."
   "Handle tools/call request with ID and PARAMS from CLIENT-ID."
   (mcp-server--debug "Tools call request from %s: %s" client-id params)
 
-  (let ((tool-name (alist-get 'name params))
-        (arguments (alist-get 'arguments params)))
+  (unwind-protect
+      (let ((tool-name (alist-get 'name params))
+            (arguments (alist-get 'arguments params)))
 
-    (condition-case err
-        (let* ((result (mcp-server-tools-call tool-name arguments))
+        (condition-case err
+            (let* ((result (mcp-server-tools-call tool-name arguments))
                ;; Check if this is an error result
                (is-error-bool (and (> (length result) 0)
                                    (listp (aref result 0))
@@ -392,7 +393,10 @@ Uses `catch'/`throw' for early exit after successful response send."
       client-id id
       `((content . (((type . "text")
                      (text . "Tool execution failed"))))
-        (isError . t))))))
+        (isError . t)))))
+    ;; Cleanup: close clean unmodified temporary buffers opened by org tools.
+    (when (bound-and-true-p mcp-server-emacs-tools-org--owned-buffers)
+      (mcp-server-emacs-tools-org--cleanup-buffers))))
 
 (defun mcp-server--send-error (client-id id code message &optional data)
   "Send error response to CLIENT-ID with ID, CODE, MESSAGE and optional DATA."

--- a/test/unit/test-mcp-org-common.el
+++ b/test/unit/test-mcp-org-common.el
@@ -216,5 +216,66 @@ must never split a multibyte character."
   (should (equal (mcp-server-emacs-tools-org-common--truncate-to-bytes "anything" 0)
                  "")))
 
+;; ─── Temporary buffer ownership tests ───
+
+(ert-deftest mcp-test-org-common-open-file-tracks-new ()
+  "open-file records newly opened buffers for cleanup."
+  (let* ((tmp-file (make-temp-file "mcp-test-" nil ".org" "#+TITLE: test\n"))
+         (buf (mcp-server-emacs-tools-org--open-file tmp-file))
+         (owned mcp-server-emacs-tools-org--owned-buffers))
+    (unwind-protect
+        (should (assoc buf owned))
+      (when (buffer-live-p buf) (kill-buffer buf))
+      (delete-file tmp-file))))
+
+(ert-deftest mcp-test-org-common-open-file-reuses-existing ()
+  "open-file does NOT track buffers that were already visiting."
+  (let* ((tmp-file (make-temp-file "mcp-test-" nil ".org" "#+TITLE: test\n"))
+         (existing-buf (find-file-noselect tmp-file)))
+    (unwind-protect
+        (let* ((owned-before (length (or mcp-server-emacs-tools-org--owned-buffers '())))
+               (same-buf (mcp-server-emacs-tools-org--open-file tmp-file))
+               (owned-after (length (or mcp-server-emacs-tools-org--owned-buffers '()))))
+          (should (eq same-buf existing-buf))
+          (should (= owned-before owned-after)))
+      (when (buffer-live-p existing-buf) (kill-buffer existing-buf))
+      (delete-file tmp-file))))
+
+(ert-deftest mcp-test-org-common-cleanup-kills-new-clean-buffer ()
+  "cleanup-buffers kills a newly opened clean buffer."
+  (let* ((tmp-file (make-temp-file "mcp-test-" nil ".org" "#+TITLE: test\n"))
+         (buf (find-file-noselect tmp-file)))
+    (unwind-protect
+        (let ((mcp-server-emacs-tools-org--owned-buffers `((,buf . nil))))
+          (mcp-server-emacs-tools-org--cleanup-buffers)
+          (should-not (buffer-live-p buf)))
+      (when (buffer-live-p buf) (kill-buffer buf))
+      (delete-file tmp-file))))
+
+(ert-deftest mcp-test-org-common-cleanup-preserves-modified ()
+  "cleanup-buffers does NOT kill a modified buffer."
+  (let* ((tmp-file (make-temp-file "mcp-test-" nil ".org" "#+TITLE: test\n"))
+         (buf (find-file-noselect tmp-file)))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (insert "dirty"))
+          (let ((mcp-server-emacs-tools-org--owned-buffers `((,buf . nil))))
+            (mcp-server-emacs-tools-org--cleanup-buffers)
+            (should (buffer-live-p buf))))
+      (when (buffer-live-p buf) (kill-buffer buf))
+      (delete-file tmp-file))))
+
+(ert-deftest mcp-test-org-common-cleanup-ignores-unowned ()
+  "cleanup-buffers does not kill buffers it did not open."
+  (let* ((tmp-file (make-temp-file "mcp-test-" nil ".org" "#+TITLE: test\n"))
+         (buf (find-file-noselect tmp-file)))
+    (unwind-protect
+        (progn
+          (mcp-server-emacs-tools-org--cleanup-buffers)
+          (should (buffer-live-p buf)))
+      (when (buffer-live-p buf) (kill-buffer buf))
+      (delete-file tmp-file))))
+
 (provide 'test-mcp-org-common)
 ;;; test-mcp-org-common.el ends here

--- a/test/unit/test-mcp-org-common.el
+++ b/test/unit/test-mcp-org-common.el
@@ -9,6 +9,8 @@
   (when tools-dir (add-to-list 'load-path tools-dir)))
 
 (require 'mcp-server-emacs-tools-org-common)
+(require 'mcp-server)
+(require 'mcp-server-tools)
 
 (ert-deftest mcp-test-org-common-defcustoms-exist ()
   "Config defcustoms are defined with expected defaults."
@@ -276,6 +278,87 @@ must never split a multibyte character."
           (should (buffer-live-p buf)))
       (when (buffer-live-p buf) (kill-buffer buf))
       (delete-file tmp-file))))
+
+;; ─── Dispatch-level cleanup tests ───
+
+(ert-deftest mcp-test-org-common-dispatch-cleanup-on-success ()
+  "Dispatch cleanup runs after a successful tool call."
+  (let* ((tmp-file (make-temp-file "mcp-dispatch-" nil ".org" "#+TITLE: test\n"))
+         sent-msg)
+    (mcp-server-tools-init)
+    (mcp-server-register-tool
+     (make-mcp-server-tool
+      :name "mcp-test-cleanup-ok"
+      :function (lambda (_args)
+                  (mcp-server-emacs-tools-org--open-file tmp-file)
+                  (vector `((type . "text") (text . "ok"))))))
+    (cl-letf (((symbol-function 'mcp-server-transport-send-raw)
+               (lambda (&rest args) (setq sent-msg args) "mocked"))
+              ((symbol-function 'mcp-server-transport-send)
+               (lambda (&rest args) (setq sent-msg args) "mocked"))
+              (mcp-server-current-transport "unix"))
+      (let ((owned-before (length mcp-server-emacs-tools-org--owned-buffers)))
+        (catch 'mcp-handled
+          (mcp-server--handle-tools-call
+           1 '((name . "mcp-test-cleanup-ok") (arguments)) "test-client"))
+        (let ((owned-after (length mcp-server-emacs-tools-org--owned-buffers)))
+          (should (= owned-after 0))
+          (should-not (find-buffer-visiting tmp-file))
+          (should sent-msg))))))
+
+(ert-deftest mcp-test-org-common-dispatch-cleanup-on-error ()
+  "Dispatch cleanup runs after a tool error, even on throw."
+  (mcp-test-with-mock-server
+   (let* ((tmp-file (make-temp-file "mcp-dispatch-" nil ".org" "#+TITLE: test\n"))
+          (tool-name (concat "test-error-tool-" (format-time-string "%s%N"))))
+     (mcp-server-register-tool
+      (make-mcp-server-tool
+       :name tool-name
+       :function (lambda (_args)
+                   (mcp-server-emacs-tools-org--open-file tmp-file)
+                   (error "simulated tool error"))))
+     (cl-letf (((symbol-function 'mcp-server-transport-send)
+                (lambda (&rest _) "mocked"))
+               (mcp-server-current-transport "unix"))
+       (let ((owned-before (length mcp-server-emacs-tools-org--owned-buffers)))
+         (catch 'mcp-handled
+           (condition-case nil
+               (mcp-server--handle-tools-call
+                1 `((name . ,tool-name) (arguments)) "test-client")
+             (error nil)))
+         (let ((owned-after (length mcp-server-emacs-tools-org--owned-buffers)))
+           (should (= owned-after 0))
+           (should-not (find-buffer-visiting tmp-file))))))))
+
+(ert-deftest mcp-test-org-common-dispatch-preserves-previous-buffer ()
+  "Dispatch cleanup preserves a buffer that was already visiting."
+  (let* ((tmp-file (make-temp-file "mcp-dispatch-" nil ".org" "#+TITLE: test\n"))
+         (prev-buf (find-file-noselect tmp-file))
+         (tool-name (concat "test-open-file-" (format-time-string "%s%N"))))
+    (mcp-test-with-mock-server
+     (mcp-server-register-tool
+      (make-mcp-server-tool
+       :name tool-name
+       :function (lambda (_args)
+                   ;; Open a different file; prev-buf was already open
+                   (mcp-server-emacs-tools-org--open-file tmp-file)
+                   (vector `((type . "text") (text . "ok"))))))
+     (cl-letf (((symbol-function 'mcp-server-transport-send-raw)
+                (lambda (&rest _) "mocked"))
+               ((symbol-function 'mcp-server-transport-send)
+                (lambda (&rest _) "mocked"))
+               (mcp-server-current-transport "unix"))
+       (let ((owned-before (length mcp-server-emacs-tools-org--owned-buffers)))
+         (catch 'mcp-handled
+           (mcp-server--handle-tools-call
+            1 `((name . ,tool-name) (arguments)) "test-client"))
+         (let ((owned-after (length mcp-server-emacs-tools-org--owned-buffers)))
+           (should (= owned-after 0))
+           ;; Pre-existing buffer remains alive and visiting
+           (should (buffer-live-p prev-buf))
+           (should (eq prev-buf (find-buffer-visiting tmp-file)))))))
+    (when (buffer-live-p prev-buf) (kill-buffer prev-buf))
+    (delete-file tmp-file)))
 
 (provide 'test-mcp-org-common)
 ;;; test-mcp-org-common.el ends here

--- a/test/unit/test-mcp-org-common.el
+++ b/test/unit/test-mcp-org-common.el
@@ -228,7 +228,8 @@ must never split a multibyte character."
     (unwind-protect
         (should (assoc buf owned))
       (when (buffer-live-p buf) (kill-buffer buf))
-      (delete-file tmp-file))))
+      (delete-file tmp-file))
+    (setq mcp-server-emacs-tools-org--owned-buffers nil)))
 
 (ert-deftest mcp-test-org-common-open-file-reuses-existing ()
   "open-file does NOT track buffers that were already visiting."
@@ -241,7 +242,8 @@ must never split a multibyte character."
           (should (eq same-buf existing-buf))
           (should (= owned-before owned-after)))
       (when (buffer-live-p existing-buf) (kill-buffer existing-buf))
-      (delete-file tmp-file))))
+      (delete-file tmp-file))
+    (setq mcp-server-emacs-tools-org--owned-buffers nil)))
 
 (ert-deftest mcp-test-org-common-cleanup-kills-new-clean-buffer ()
   "cleanup-buffers kills a newly opened clean buffer."
@@ -304,7 +306,8 @@ must never split a multibyte character."
         (let ((owned-after (length mcp-server-emacs-tools-org--owned-buffers)))
           (should (= owned-after 0))
           (should-not (find-buffer-visiting tmp-file))
-          (should sent-msg))))))
+          (should sent-msg))))
+    (setq mcp-server-emacs-tools-org--owned-buffers nil)))
 
 (ert-deftest mcp-test-org-common-dispatch-cleanup-on-error ()
   "Dispatch cleanup runs after a tool error, even on throw."
@@ -328,7 +331,8 @@ must never split a multibyte character."
              (error nil)))
          (let ((owned-after (length mcp-server-emacs-tools-org--owned-buffers)))
            (should (= owned-after 0))
-           (should-not (find-buffer-visiting tmp-file))))))))
+           (should-not (find-buffer-visiting tmp-file)))
+          (setq mcp-server-emacs-tools-org--owned-buffers nil))))))
 
 (ert-deftest mcp-test-org-common-dispatch-preserves-previous-buffer ()
   "Dispatch cleanup preserves a buffer that was already visiting."
@@ -356,7 +360,8 @@ must never split a multibyte character."
            (should (= owned-after 0))
            ;; Pre-existing buffer remains alive and visiting
            (should (buffer-live-p prev-buf))
-           (should (eq prev-buf (find-buffer-visiting tmp-file)))))))
+           (should (eq prev-buf (find-buffer-visiting tmp-file))))
+          (setq mcp-server-emacs-tools-org--owned-buffers nil))))
     (when (buffer-live-p prev-buf) (kill-buffer prev-buf))
     (delete-file tmp-file)))
 

--- a/test/unit/test-mcp-org-common.el
+++ b/test/unit/test-mcp-org-common.el
@@ -226,7 +226,7 @@ must never split a multibyte character."
          (buf (mcp-server-emacs-tools-org--open-file tmp-file))
          (owned mcp-server-emacs-tools-org--owned-buffers))
     (unwind-protect
-        (should (assoc buf owned))
+        (should (memq buf owned))
       (when (buffer-live-p buf) (kill-buffer buf))
       (delete-file tmp-file))
     (setq mcp-server-emacs-tools-org--owned-buffers nil)))
@@ -250,7 +250,7 @@ must never split a multibyte character."
   (let* ((tmp-file (make-temp-file "mcp-test-" nil ".org" "#+TITLE: test\n"))
          (buf (find-file-noselect tmp-file)))
     (unwind-protect
-        (let ((mcp-server-emacs-tools-org--owned-buffers `((,buf . nil))))
+        (let ((mcp-server-emacs-tools-org--owned-buffers (list buf)))
           (mcp-server-emacs-tools-org--cleanup-buffers)
           (should-not (buffer-live-p buf)))
       (when (buffer-live-p buf) (kill-buffer buf))
@@ -264,7 +264,7 @@ must never split a multibyte character."
         (progn
           (with-current-buffer buf
             (insert "dirty"))
-          (let ((mcp-server-emacs-tools-org--owned-buffers `((,buf . nil))))
+          (let ((mcp-server-emacs-tools-org--owned-buffers (list buf)))
             (mcp-server-emacs-tools-org--cleanup-buffers)
             (should (buffer-live-p buf))))
       (when (buffer-live-p buf) (kill-buffer buf))

--- a/tools/mcp-server-emacs-tools-org-agenda.el
+++ b/tools/mcp-server-emacs-tools-org-agenda.el
@@ -18,7 +18,7 @@
   (let ((entries '()))
     (dolist (file files)
       (when (file-exists-p file)
-        (with-current-buffer (find-file-noselect file)
+        (with-current-buffer (mcp-server-emacs-tools-org--open-file file)
           (org-with-wide-buffer
            (org-map-entries
             (lambda ()

--- a/tools/mcp-server-emacs-tools-org-capture.el
+++ b/tools/mcp-server-emacs-tools-org-capture.el
@@ -269,7 +269,7 @@ prompts via org APIs."
          (properties (alist-get 'properties args))
          (scheduled (alist-get 'scheduled args))
          (deadline (alist-get 'deadline args))
-         (buf (find-file-noselect file)))
+         (buf (mcp-server-emacs-tools-org--open-file file)))
     (with-current-buffer buf
       (org-with-wide-buffer
        (let (insert-marker level)

--- a/tools/mcp-server-emacs-tools-org-common.el
+++ b/tools/mcp-server-emacs-tools-org-common.el
@@ -337,22 +337,23 @@ BASE is returned unchanged."
 
 (defvar mcp-server-emacs-tools-org--owned-buffers nil
   "List of buffers opened by the current MCP tool call.
-Each element is (BUFFER . WAS-ALREADY-VISITING).
-Cleaned up by `mcp-server-emacs-tools-org--cleanup-buffers' after each tool call.")
+Only newly opened, clean buffers are tracked; pre-existing buffers
+are not added.  Cleaned up by `mcp-server-emacs-tools-org--cleanup-buffers'
+after each tool call.")
 
 (defun mcp-server-emacs-tools-org--open-file (file)
   "Open FILE with ownership tracking.
 
 Returns a live buffer visiting FILE.  If FILE was already visiting
-a buffer, the existing buffer is reused and will NOT be closed by
-cleanup.  If FILE was not yet visiting, the buffer is recorded in
-`mcp-server-emacs-tools-org--owned-buffers' and will be closed by
-`mcp-server-emacs-tools-org--cleanup-buffers' after the tool call
-completes, provided it remains clean and unmodified."
+a buffer, the existing buffer is reused and will NOT be added to
+`mcp-server-emacs-tools-org--owned-buffers' and will therefore not
+be closed by cleanup.  If FILE was not yet visiting, the buffer is
+appended to the ownership list and will be closed by cleanup after
+the tool call completes, provided it remains clean and unmodified."
   (let* ((was-open (find-buffer-visiting file))
          (buf (find-file-noselect file)))
     (unless was-open
-      (push (cons buf was-open) mcp-server-emacs-tools-org--owned-buffers))
+      (push buf mcp-server-emacs-tools-org--owned-buffers))
     buf))
 
 (defun mcp-server-emacs-tools-org--cleanup-buffers ()
@@ -361,11 +362,10 @@ completes, provided it remains clean and unmodified."
 User-opened buffers (already visiting before the tool call) and
 modified buffers are preserved.  Intended to be called from
 `unwind-protect' in `mcp-server--handle-tools-call'."
-  (dolist (entry mcp-server-emacs-tools-org--owned-buffers)
-    (let ((buf (car entry)))
-      (when (and (buffer-live-p buf)
-                 (not (buffer-modified-p buf)))
-        (kill-buffer buf))))
+  (dolist (buf mcp-server-emacs-tools-org--owned-buffers)
+    (when (and (buffer-live-p buf)
+               (not (buffer-modified-p buf)))
+      (kill-buffer buf)))
   (setq mcp-server-emacs-tools-org--owned-buffers nil))
 
 (provide 'mcp-server-emacs-tools-org-common)

--- a/tools/mcp-server-emacs-tools-org-common.el
+++ b/tools/mcp-server-emacs-tools-org-common.el
@@ -111,7 +111,7 @@ heading (not a file-level marker) should use
         location))
      ((and file olp)
       (mcp-server-emacs-tools-org-common--validate-path file)
-      (let* ((buf (find-file-noselect file))
+      (let* ((buf (mcp-server-emacs-tools-org--open-file file))
              (path-list (append olp nil)))
         (condition-case err
             (with-current-buffer buf
@@ -120,7 +120,7 @@ heading (not a file-level marker) should use
            (error "Outline path not found in %s: %S" file path-list)))))
      (file
       (mcp-server-emacs-tools-org-common--validate-path file)
-      (let ((buf (find-file-noselect file)))
+      (let ((buf (mcp-server-emacs-tools-org--open-file file)))
         (with-current-buffer buf
           (save-excursion
             (goto-char (point-min))
@@ -332,6 +332,41 @@ BASE is returned unchanged."
    ((and (eq hint-kind 'roam-hint) (featurep 'org-roam))
     (concat base mcp-server-emacs-tools-org-common--roam-hint))
    (t base)))
+
+;; ─── Temporary buffer ownership tracking ───
+
+(defvar mcp-server-emacs-tools-org--owned-buffers nil
+  "List of buffers opened by the current MCP tool call.
+Each element is (BUFFER . WAS-ALREADY-VISITING).
+Cleaned up by `mcp-server-emacs-tools-org--cleanup-buffers' after each tool call.")
+
+(defun mcp-server-emacs-tools-org--open-file (file)
+  "Open FILE with ownership tracking.
+
+Returns a live buffer visiting FILE.  If FILE was already visiting
+a buffer, the existing buffer is reused and will NOT be closed by
+cleanup.  If FILE was not yet visiting, the buffer is recorded in
+`mcp-server-emacs-tools-org--owned-buffers' and will be closed by
+`mcp-server-emacs-tools-org--cleanup-buffers' after the tool call
+completes, provided it remains clean and unmodified."
+  (let* ((was-open (find-buffer-visiting file))
+         (buf (find-file-noselect file)))
+    (unless was-open
+      (push (cons buf was-open) mcp-server-emacs-tools-org--owned-buffers))
+    buf))
+
+(defun mcp-server-emacs-tools-org--cleanup-buffers ()
+  "Kill clean unmodified buffers that were opened by the current tool call.
+
+User-opened buffers (already visiting before the tool call) and
+modified buffers are preserved.  Intended to be called from
+`unwind-protect' in `mcp-server--handle-tools-call'."
+  (dolist (entry mcp-server-emacs-tools-org--owned-buffers)
+    (let ((buf (car entry)))
+      (when (and (buffer-live-p buf)
+                 (not (buffer-modified-p buf)))
+        (kill-buffer buf))))
+  (setq mcp-server-emacs-tools-org--owned-buffers nil))
 
 (provide 'mcp-server-emacs-tools-org-common)
 

--- a/tools/mcp-server-emacs-tools-org-list-tags.el
+++ b/tools/mcp-server-emacs-tools-org-list-tags.el
@@ -48,7 +48,7 @@ Mirrors `mcp-server-emacs-tools-org-search--scope-files'."
   (let ((counts (make-hash-table :test 'equal)))
     (dolist (file files)
       (when (file-exists-p file)
-        (with-current-buffer (find-file-noselect file)
+        (with-current-buffer (mcp-server-emacs-tools-org--open-file file)
           (org-with-wide-buffer
            (org-map-entries
             (lambda ()

--- a/tools/mcp-server-emacs-tools-org-roam-capture.el
+++ b/tools/mcp-server-emacs-tools-org-roam-capture.el
@@ -61,7 +61,7 @@ unset or the ID can't be read from the captured buffer."
           ;; Apply post-capture edits BEFORE syncing the DB so aliases,
           ;; refs, and filetags end up indexed.
           (when (or tags aliases refs)
-            (with-current-buffer (find-file-noselect file)
+            (with-current-buffer (mcp-server-emacs-tools-org--open-file file)
               (save-excursion
                 (goto-char (point-min))
                 (when aliases

--- a/tools/mcp-server-emacs-tools-org-search.el
+++ b/tools/mcp-server-emacs-tools-org-search.el
@@ -48,7 +48,7 @@ SCOPE is a string; FILES and DIRECTORY are optional supporting args."
         (catch 'done
           (dolist (file resolved)
             (when (file-exists-p file)
-              (with-current-buffer (find-file-noselect file)
+              (with-current-buffer (mcp-server-emacs-tools-org--open-file file)
                 (org-with-wide-buffer
                  (org-map-entries
                   (lambda ()


### PR DESCRIPTION
## Problem

All built-in org MCP tools (org-search, org-list-tags, org-agenda, org-capture, org-roam-capture, org-get-node, etc.) use `find-file-noselect` to open org files for processing, but never close the buffers afterward. Over time, every file accessed via MCP tools accumulates as a permanent buffer, bloating the buffer list.

## Solution

Add ownership tracking and automatic cleanup of temporary org buffers:

1. `mcp-server-emacs-tools-org--open-file` — ownership-aware file opener that records newly opened buffers
2. `mcp-server-emacs-tools-org--owned-buffers` — per-call list of tracked buffers
3. `mcp-server-emacs-tools-org--cleanup-buffers` — kills only clean, unmodified tracked buffers; preserves pre-existing and modified ones
4. `mcp-server--handle-tools-call` wraps in `unwind-protect` so cleanup runs after success, errors, AND the `throw 'mcp-handled` non-local exit

All 7 direct `find-file-noselect` call sites across the codebase now use `--open-file`.

## Testing

- 5 new ERT tests in test-mcp-org-common.el covering: new file tracking, existing file reuse, clean buffer cleanup, modified buffer preservation, and unowned buffer safety
- Existing 6 integration tests all pass
- Manual verification via `emacs_eval-elisp` confirms correct buffer lifecycle