### PR TITLE
fix: safe Unix socket lifecycle with kill-emacs-hook and stale cleanup

### DIFF
--- a/mcp-server-transport-unix.el
+++ b/mcp-server-transport-unix.el
@@ -316,6 +316,23 @@
 
 ;;; Transport Implementation
 
+(defun mcp-server-transport-unix--cleanup-stale-sockets ()
+  "Remove stale numbered socket files from the socket directory.
+Performs a liveness test before unlinking; active sockets are never deleted."
+  (let* ((dir (when mcp-server-transport-unix--socket-path
+                (file-name-directory mcp-server-transport-unix--socket-path)))
+         (current (when mcp-server-transport-unix--socket-path
+                    (file-name-nondirectory mcp-server-transport-unix--socket-path))))
+    (when dir
+      (dolist (f (directory-files dir t "^emacs-mcp-server-.*\\.sock$"))
+        (let ((basename (file-name-nondirectory f)))
+          (when (and (not (equal basename current))
+                     (mcp-server-transport-unix--is-socket-stale f))
+            (mcp-server-transport-unix--info "Removing stale socket: %s" f)
+            (condition-case nil
+                (delete-file f)
+              (error nil))))))))
+
 (defun mcp-server-transport-unix--start (message-handler &optional socket-path)
   "Start Unix domain socket server with MESSAGE-HANDLER at optional SOCKET-PATH."
   (when mcp-server-transport-unix--running
@@ -324,7 +341,10 @@
   (setq mcp-server-transport-unix--socket-path 
         (mcp-server-transport-unix--generate-socket-path socket-path))
   
-  ;; Clean up any existing socket file
+  ;; Clean up stale numbered sockets from previous sessions
+  (mcp-server-transport-unix--cleanup-stale-sockets)
+  
+  ;; Clean up any existing socket file matching our path
   (mcp-server-transport-unix--cleanup-socket mcp-server-transport-unix--socket-path)
   
   (setq mcp-server-transport-unix--message-handler message-handler)
@@ -345,6 +365,10 @@
         ;; Set proper permissions on socket file (read/write for owner only, not executable)
         (when (file-exists-p mcp-server-transport-unix--socket-path)
           (set-file-modes mcp-server-transport-unix--socket-path #o600))
+        
+        ;; Register kill-emacs-hook for clean shutdown.
+        ;; add-hook deduplicates, and --stop is idempotent.
+        (add-hook 'kill-emacs-hook #'mcp-server-transport-unix--stop)
         
         (setq mcp-server-transport-unix--running t)
         (mcp-server-transport-unix--info "Unix socket MCP server started at: %s" mcp-server-transport-unix--socket-path))

--- a/test/unit/test-mcp-transport-unix.el
+++ b/test/unit/test-mcp-transport-unix.el
@@ -1,0 +1,79 @@
+;;; test-mcp-transport-unix.el --- Tests for unix transport socket lifecycle -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Regression tests for Unix domain socket lifecycle management:
+;; stale-socket cleanup, active-socket preservation, stop idempotency,
+;; and kill-emacs-hook registration.
+
+;;; Code:
+
+(require 'ert)
+(require 'test-helpers)
+(require 'mcp-server)
+(require 'mcp-server-transport-unix)
+
+(ert-deftest mcp-test-transport-cleanup-stale-socket ()
+  "Cleanup removes a numbered socket file that is stale."
+  (mcp-test-with-temp-dir
+    (let ((mcp-server-transport-unix--socket-path
+           (expand-file-name "emacs-mcp-server-test.sock" mcp-test-temp-dir))
+          (stale-sock (expand-file-name "emacs-mcp-server-1.sock" mcp-test-temp-dir)))
+      (with-temp-file stale-sock (insert "stale"))
+      (mcp-server-transport-unix--cleanup-stale-sockets)
+      (should-not (file-exists-p stale-sock)))))
+
+(ert-deftest mcp-test-transport-preserves-active-socket ()
+  "Cleanup preserves a numbered socket that is a live Unix socket."
+  (mcp-test-with-temp-dir
+    (let* ((mcp-server-transport-unix--socket-path
+            (expand-file-name "emacs-mcp-server-test.sock" mcp-test-temp-dir))
+           (live-sock (expand-file-name "emacs-mcp-server-2.sock" mcp-test-temp-dir))
+           (server-proc (make-network-process
+                         :name "test-live-sock"
+                         :family 'local
+                         :service live-sock
+                         :server t
+                         :noquery t)))
+      (unwind-protect
+          (progn
+            (mcp-server-transport-unix--cleanup-stale-sockets)
+            (should (file-exists-p live-sock)))
+        (when (processp server-proc)
+          (delete-process server-proc))
+        (when (file-exists-p live-sock)
+          (delete-file live-sock))))))
+
+(ert-deftest mcp-test-transport-stop-idempotent ()
+  "Calling --stop multiple times does not error."
+  (mcp-test-with-temp-dir
+    (let ((socket-path (expand-file-name "mcp-test.sock" mcp-test-temp-dir)))
+      (unwind-protect
+          (progn
+            (mcp-server-transport-unix--start (lambda (&rest _) t) socket-path)
+            (mcp-server-transport-unix--stop)
+            (mcp-server-transport-unix--stop)
+            (should-not mcp-server-transport-unix--running))
+        (when mcp-server-transport-unix--server-process
+          (delete-process mcp-server-transport-unix--server-process))
+        (setq mcp-server-transport-unix--running nil
+              mcp-server-transport-unix--socket-path nil
+              mcp-server-transport-unix--message-handler nil)
+        (remove-hook 'kill-emacs-hook 'mcp-server-transport-unix--stop)))))
+
+(ert-deftest mcp-test-transport-kill-hook-registration ()
+  "Starting the transport adds --stop to kill-emacs-hook."
+  (mcp-test-with-temp-dir
+    (let ((socket-path (expand-file-name "mcp-test.sock" mcp-test-temp-dir)))
+      (unwind-protect
+          (progn
+            (mcp-server-transport-unix--start (lambda (&rest _) t) socket-path)
+            (should (member 'mcp-server-transport-unix--stop kill-emacs-hook)))
+        (when mcp-server-transport-unix--server-process
+          (delete-process mcp-server-transport-unix--server-process))
+        (setq mcp-server-transport-unix--running nil
+              mcp-server-transport-unix--socket-path nil
+              mcp-server-transport-unix--message-handler nil)
+        (remove-hook 'kill-emacs-hook 'mcp-server-transport-unix--stop)))))
+
+(provide 'test-mcp-transport-unix)
+;;; test-mcp-transport-unix.el ends here


### PR DESCRIPTION
## Problem

When Emacs exits, the MCP server's Unix socket is not explicitly cleaned up. While the kernel releases the socket binding, the socket file can remain on disk. Additionally, numbered fallback sockets (`emacs-mcp-server-1.sock` etc.) accumulate across sessions when the default socket is unavailable, and are never cleaned up.

## Solution

1. Register `kill-emacs-hook` in `--start` (add-hook deduplicates) so the transport stops cleanly on Emacs exit. The `--stop` function is already idempotent (checks `mcp-server-transport-unix--running`).

2. Add `mcp-server-transport-unix--cleanup-stale-sockets` that scans for numbered `emacs-mcp-server-*.sock` files on startup and removes only those that fail the liveness test (active sockets are never unlinked).

3. Conflict resolution semantics are preserved (default remains `'warn`, not `'force`).