### PR TITLE
Disable process-exit-query for the mcp server

### DIFF
--- a/mcp-server-transport-unix.el
+++ b/mcp-server-transport-unix.el
@@ -261,6 +261,8 @@
     (set-process-filter client-process #'mcp-server-transport-unix--client-filter)
     (set-process-sentinel client-process #'mcp-server-transport-unix--client-sentinel)
     (set-process-coding-system client-process 'utf-8 'utf-8)
+    ;; Don't prompt about this connection when Emacs exits.
+    (set-process-query-on-exit-flag client-process nil)
     
     ;; Add to client table
     (mcp-server-transport-unix--add-client client-id client-process)
@@ -341,7 +343,11 @@
                :filter #'mcp-server-transport-unix--server-filter
                :sentinel #'mcp-server-transport-unix--server-sentinel
                :coding 'utf-8))
-        
+
+        ;; Don't prompt about this process when Emacs exits; the server should
+        ;; be torn down unconditionally on shutdown.
+        (set-process-query-on-exit-flag mcp-server-transport-unix--server-process nil)
+
         ;; Set proper permissions on socket file (read/write for owner only, not executable)
         (when (file-exists-p mcp-server-transport-unix--socket-path)
           (set-file-modes mcp-server-transport-unix--socket-path #o600))

--- a/test/unit/test-mcp-server-full.el
+++ b/test/unit/test-mcp-server-full.el
@@ -149,5 +149,20 @@ not found) which is the correct response."
           (should-not mcp-server-debug))
       (setq mcp-server-debug original-debug))))
 
+(ert-deftest mcp-test-unix-server-process-query-on-exit-cleared ()
+  "Unix server process must not block Emacs exit.
+The server is a persistent network process; leaving its
+query-on-exit flag set makes Emacs prompt about \"active processes\"
+on shutdown. Starting the server must clear that flag so it is torn
+down unconditionally."
+  (require 'mcp-server-transport-unix)
+  (unwind-protect
+      (progn
+        (mcp-server-start-unix)
+        (should (processp mcp-server-transport-unix--server-process))
+        (should-not
+         (process-query-on-exit-flag mcp-server-transport-unix--server-process)))
+    (mcp-server-stop)))
+
 (provide 'test-mcp-server-full)
 ;;; test-mcp-server-full.el ends here


### PR DESCRIPTION
I don't think we need to ask if this process should block closing emacs; it should not, so we should close emacs unconditionally if this is the only blocking process.